### PR TITLE
Added tmpfs to frost_mqtt

### DIFF
--- a/frost/docker-compose.yml
+++ b/frost/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.6' # This needs to be at leas 3.6 otherwise the tmpfs will not work
 services:
   write:
     image: fraunhoferiosb/frost-server-http:1.11.1
@@ -71,6 +71,8 @@ services:
 
   mqtt:
     image: fraunhoferiosb/frost-server-mqtt:1.11.1
+    tmpfs:
+      - /tmp
     networks:
       - traefik
       - mqtt-broker

--- a/frost/docker-compose.yml
+++ b/frost/docker-compose.yml
@@ -71,8 +71,6 @@ services:
 
   mqtt:
     image: fraunhoferiosb/frost-server-mqtt:1.11.1
-    tmpfs:
-      - /tmp
     networks:
       - traefik
       - mqtt-broker
@@ -89,6 +87,11 @@ services:
       - persistence_db_url=jdbc:postgresql://postgis_master:5432/sensorthings
       - persistence_db_username=sensorthings
       - persistence_db_password=ChangeMe
+    volumes:
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 4294967296 # 4GiB
     deploy:
       mode: global
       placement:


### PR DESCRIPTION
I added a tmpfs for the `/tmp` where the temporary `moquette_store.mapdb` is stored.

These files are responsible for high IO utilization as soon as the DB has reached its max RAM size (probably around 1GB).
After that, it all operations with this DB requires access to the `moquette_store.mapdb` files.
Because the application is running in a docker container `/tmp` is not on a tmpfs by default and therefore reads and writes over 500GB of data a day.