### PR TITLE
Fix: Letsencrypt Cert - Updated Traefik

### DIFF
--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   traefik:
-    image: traefik:v2.1.1
+    image: traefik:v2.2.1
     command:
       - '--api=true'
       - '--api.dashboard=true'


### PR DESCRIPTION
Updated traefik version from 2.1.1 to 2.2.1 which fixed the certificate issue