### PR TITLE
Disabled inbound_packets_dropped_ratio for eth0

### DIFF
--- a/netdata/health.d/net.conf
+++ b/netdata/health.d/net.conf
@@ -84,7 +84,7 @@ template: inbound_packets_dropped_ratio
       on: net.packets
       os: linux
    hosts: *
-families: *
+families: !eth0 *
   lookup: sum -10m unaligned absolute of received
     calc: (($inbound_packets_dropped != nan AND $this > 0) ? ($inbound_packets_dropped * 100 / $this) : (0))
    units: %


### PR DESCRIPTION
This disables the inbound_packets_dropped_ratio health check for interface eth0.

eth0 is only used to connect the node with the internet.
It is not relevant for swarm communications and therefore has next to zero traffic.
However, it received a small number of irrelevant broadcast packages which then will be dropped causing the health check to fail tremendously often.
This change disables the check for eth0 lowering the number of warnings and errors.